### PR TITLE
Fix bug where a macro produced an expression when it should be a pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.20.0
+  - 1.21.0
   - stable
   - beta
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.22.0
+  - 1.24.1
   - stable
   - beta
   - nightly
@@ -8,7 +8,7 @@ script:
   - cargo build --verbose
   - cargo test --verbose
   - cargo doc
-  - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
+  - if [ "$TRAVIS_RUST_VERSION" != "1.24.1" ]; then
       cargo build --verbose --manifest-path quickcheck_macros/Cargo.toml;
       cargo test --verbose --manifest-path quickcheck_macros/Cargo.toml;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.21.0
+  - 1.22.0
   - stable
   - beta
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.22.0
+  - 1.24.1
   - stable
   - beta
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,5 @@ script:
       cargo build --verbose --manifest-path quickcheck_macros/Cargo.toml;
       cargo test --verbose --manifest-path quickcheck_macros/Cargo.toml;
     fi
-  - if [ "$TRAVIS_RUST_VERSION" != "1.12.0" ]; then
-      cargo build --verbose --manifest-path quickcheck_derive/Cargo.toml;
-      cargo test --verbose --manifest-path quickcheck_derive/Cargo.toml;
-    fi
+  - cargo build --verbose --manifest-path quickcheck_derive/Cargo.toml;
+  - cargo test --verbose --manifest-path quickcheck_derive/Cargo.toml;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.24.1
+  - 1.30.0
   - stable
   - beta
   - nightly
@@ -8,7 +8,5 @@ script:
   - cargo build --verbose
   - cargo test --verbose
   - cargo doc
-  - if [ "$TRAVIS_RUST_VERSION" != "1.24.1" ]; then
-      cargo build --verbose --manifest-path quickcheck_macros/Cargo.toml;
-      cargo test --verbose --manifest-path quickcheck_macros/Cargo.toml;
-    fi
+  - cargo build --verbose --manifest-path quickcheck_macros/Cargo.toml
+  - cargo test --verbose --manifest-path quickcheck_macros/Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 keywords = ["testing", "quickcheck", "property", "shrinking", "fuzz"]
 categories = ["development-tools::testing"]
 license = "Unlicense/MIT"
+exclude = ["/.travis.yml", "/Makefile", "/ctags.rust", "/session.vim"]
 
 [features]
 default = ["regex", "use_logging"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickcheck"
-version = "0.6.2"  #:version
+version = "0.7.0"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "Automatic property based testing with shrinking."
 documentation = "http://burntsushi.net/rustdoc/quickcheck/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ name = "quickcheck"
 [dependencies]
 env_logger = { version = "0.5", default-features = false, optional = true }
 log = { version = "0.4", optional = true }
-rand = "0.4"
+rand = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickcheck"
-version = "0.7.0"  #:version
+version = "0.7.1"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "Automatic property based testing with shrinking."
 documentation = "http://burntsushi.net/rustdoc/quickcheck/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickcheck"
-version = "0.7.2"  #:version
+version = "0.8.0"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "Automatic property based testing with shrinking."
 documentation = "http://burntsushi.net/rustdoc/quickcheck/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ categories = ["development-tools::testing"]
 license = "Unlicense/MIT"
 exclude = ["/.travis.yml", "/Makefile", "/ctags.rust", "/session.vim"]
 
+[workspace]
+members = ["quickcheck_macros"]
+
 [features]
 default = ["regex", "use_logging"]
 unstable = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "Unlicense/MIT"
 exclude = ["/.travis.yml", "/Makefile", "/ctags.rust", "/session.vim"]
 
 [workspace]
-members = ["quickcheck_macros"]
+members = ["quickcheck_macros", "quickcheck_derive"]
 
 [features]
 default = ["regex", "use_logging"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ name = "quickcheck"
 env_logger = { version = "0.5", default-features = false, optional = true }
 log = { version = "0.4", optional = true }
 rand = "0.5"
+rand_core = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickcheck"
-version = "0.7.1"  #:version
+version = "0.7.2"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "Automatic property based testing with shrinking."
 documentation = "http://burntsushi.net/rustdoc/quickcheck/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,5 @@ name = "quickcheck"
 [dependencies]
 env_logger = { version = "0.5", default-features = false, optional = true }
 log = { version = "0.4", optional = true }
-rand = "0.5"
-rand_core = "0.2.1"
+rand = "0.6.3"
+rand_core = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ default = ["regex", "use_logging"]
 unstable = []
 use_logging = ["log", "env_logger"]
 regex = ["env_logger/regex"]
+derive = ["quickcheck_derive"]
 
 [lib]
 name = "quickcheck"
@@ -29,3 +30,4 @@ env_logger = { version = "0.5", default-features = false, optional = true }
 log = { version = "0.4", optional = true }
 rand = "0.6.3"
 rand_core = "0.3.0"
+quickcheck_derive = { path = "quickcheck_derive", version = "0.1.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ members = ["quickcheck_macros"]
 default = ["regex", "use_logging"]
 unstable = []
 use_logging = ["log", "env_logger"]
-i128 = ["rand/i128_support"]
 regex = ["env_logger/regex"]
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ mod tests {
 
 ```toml
 [dependencies]
-quickcheck = "0.6"
+quickcheck = "0.7"
 ```
 
 If you're only using `quickcheck` in your test code, then you can add it as a
@@ -100,15 +100,15 @@ development dependency instead:
 
 ```toml
 [dev-dependencies]
-quickcheck = "0.6"
+quickcheck = "0.7"
 ```
 
 If you want to use the `#[quickcheck]` attribute, then add `quickcheck_macros`
 
 ```toml
 [dev-dependencies]
-quickcheck = "0.6"
-quickcheck_macros = "0.6"
+quickcheck = "0.7"
+quickcheck_macros = "0.7"
 ```
 
 and only enable the `quickcheck_macros` plugin for the test build
@@ -234,7 +234,7 @@ quickcheck(prop as fn(Vec<isize>) -> TestResult);
 So now our property returns a `TestResult`, which allows us to encode a bit
 more information. There are a few more
 [convenience functions defined for the `TestResult`
-type](http://docs.rs/quickcheck/0.6.0/quickcheck/struct.TestResult.html).
+type](http://docs.rs/quickcheck/0.7/quickcheck/struct.TestResult.html).
 For example, we can't just return a `bool`, so we convert a `bool` value to a
 `TestResult`.
 
@@ -343,7 +343,7 @@ test, you won't ever notice when a failure happens.
 
 Another approach is to just ask quickcheck to run properties more
 times. You can do this either via the
-[tests()](https://docs.rs/quickcheck/0.6.2/quickcheck/struct.QuickCheck.html#method.tests)
+[tests()](https://docs.rs/quickcheck/0.7/quickcheck/struct.QuickCheck.html#method.tests)
 method, or via the `QUICKCHECK_TESTS` environment variable.
 This will cause quickcheck to run for a much longer time. Unlike,
 the loop approach this will take a bounded amount of time, which

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ the input space quickly. (It should be the same strategy used in
 [Koen Claessen's QuickCheck for
 Haskell](http://hackage.haskell.org/package/QuickCheck).)
 
-[![Build status](https://api.travis-ci.org/BurntSushi/quickcheck.svg)](https://travis-ci.org/BurntSushi/quickcheck)
+[![Build status](https://travis-ci.org/BurntSushi/quickcheck.svg?branch=master)](https://travis-ci.org/BurntSushi/quickcheck)
 [![](http://meritbadge.herokuapp.com/quickcheck)](https://crates.io/crates/quickcheck)
 
 Dual-licensed under MIT or the [UNLICENSE](http://unlicense.org).

--- a/README.md
+++ b/README.md
@@ -124,13 +124,17 @@ witnesses for failures.
 
 Crate features:
 
-- `"i128"`: Enables Arbitrary implementations for 128-bit integers.
 - `"unstable"`: Enables Arbitrary implementations that require the Rust nightly
   channel.
 - `"use_logging"`: (Enabled by default.) Enables the log messages governed
   `RUST_LOG`.
 - `"regex"`: (Enabled by default.) Enables the use of regexes with
   `env_logger`.
+
+Prior to quickcheck 0.8, this crate had an `i128` feature for enabling support
+for 128-bit integers. As of quickcheck 0.8, whose minimium supported Rust
+version is Rust 1.30.0, this feature is now provided by default and thus no
+longer available.
 
 
 ### Alternative Rust crates for property testing

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Crate features:
 The [`proptest`](https://docs.rs/proptest) crate is inspired by the
 [Hypothesis](http://hypothesis.works) framework for Python.
 You can read a comparison between `proptest` and `quickcheck`
-[here](https://docs.rs/proptest/*/proptest/#differences-between-quickcheck-and-proptest)
+[here](https://github.com/AltSysrq/proptest/blob/master/README.md#differences-between-quickcheck-and-proptest)
 and
 [here](https://github.com/AltSysrq/proptest/issues/15#issuecomment-348382287).
 In particular, `proptest` improves on the concept of shrinking. So if you've

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ mod tests {
 
 ```toml
 [dependencies]
-quickcheck = "0.7"
+quickcheck = "0.8"
 ```
 
 If you're only using `quickcheck` in your test code, then you can add it as a
@@ -100,21 +100,15 @@ development dependency instead:
 
 ```toml
 [dev-dependencies]
-quickcheck = "0.7"
+quickcheck = "0.8"
 ```
 
 If you want to use the `#[quickcheck]` attribute, then add `quickcheck_macros`
 
 ```toml
 [dev-dependencies]
-quickcheck = "0.7"
-quickcheck_macros = "0.7"
-```
-
-and only enable the `quickcheck_macros` plugin for the test build
-```rust
-#![cfg_attr(test, feature(plugin))]
-#![cfg_attr(test, plugin(quickcheck_macros))]
+quickcheck = "0.8"
+quickcheck_macros = "0.8"
 ```
 
 N.B. When using `quickcheck` (either directly or via the attributes),
@@ -238,7 +232,7 @@ quickcheck(prop as fn(Vec<isize>) -> TestResult);
 So now our property returns a `TestResult`, which allows us to encode a bit
 more information. There are a few more
 [convenience functions defined for the `TestResult`
-type](http://docs.rs/quickcheck/0.7/quickcheck/struct.TestResult.html).
+type](http://docs.rs/quickcheck/0.8/quickcheck/struct.TestResult.html).
 For example, we can't just return a `bool`, so we convert a `bool` value to a
 `TestResult`.
 
@@ -347,7 +341,7 @@ test, you won't ever notice when a failure happens.
 
 Another approach is to just ask quickcheck to run properties more
 times. You can do this either via the
-[tests()](https://docs.rs/quickcheck/0.7/quickcheck/struct.QuickCheck.html#method.tests)
+[tests()](https://docs.rs/quickcheck/0.8/quickcheck/struct.QuickCheck.html#method.tests)
 method, or via the `QUICKCHECK_TESTS` environment variable.
 This will cause quickcheck to run for a much longer time. Unlike,
 the loop approach this will take a bounded amount of time, which

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ test, you won't ever notice when a failure happens.
 
 Another approach is to just ask quickcheck to run properties more
 times. You can do this either via the
-[tests()](http://vim.wikia.com/wiki/Append_output_of_an_external_command)
+[tests()](https://docs.rs/quickcheck/0.6.2/quickcheck/struct.QuickCheck.html#method.tests)
 method, or via the `QUICKCHECK_TESTS` environment variable.
 This will cause quickcheck to run for a much longer time. Unlike,
 the loop approach this will take a bounded amount of time, which

--- a/benches/tuples.rs
+++ b/benches/tuples.rs
@@ -14,7 +14,7 @@ macro_rules! bench_shrink {
             #[bench]
             fn $fn_name(b: &mut Bencher) {
                 // Use a deterministic generator to benchmark on the same data
-                let mut gen = StdGen::new(IsaacRng::new_unseeded(), 100);
+                let mut gen = StdGen::new(IsaacRng::new_from_u64(0), 100);
                 let value: $type = Arbitrary::arbitrary(&mut gen);
 
                 b.iter(|| {

--- a/benches/tuples.rs
+++ b/benches/tuples.rs
@@ -5,7 +5,8 @@ extern crate rand;
 extern crate test;
 
 use quickcheck::{Arbitrary, StdGen};
-use rand::isaac::IsaacRng;
+use rand::prng::hc128::Hc128Rng;
+use rand::SeedableRng;
 use test::Bencher;
 
 macro_rules! bench_shrink {
@@ -14,7 +15,7 @@ macro_rules! bench_shrink {
             #[bench]
             fn $fn_name(b: &mut Bencher) {
                 // Use a deterministic generator to benchmark on the same data
-                let mut gen = StdGen::new(IsaacRng::new_from_u64(0), 100);
+                let mut gen = StdGen::new(Hc128Rng::from_seed([0u8; 32]), 100);
                 let value: $type = Arbitrary::arbitrary(&mut gen);
 
                 b.iter(|| {

--- a/quickcheck_derive/Cargo.toml
+++ b/quickcheck_derive/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.2"
 [dependencies]
 quote = "^0.3.15"
 syn = "^0.11.11"
+rand = "0.5"
 
 [dev-dependencies.quickcheck]
 path = ".."

--- a/quickcheck_derive/Cargo.toml
+++ b/quickcheck_derive/Cargo.toml
@@ -12,7 +12,6 @@ version = "0.1.2"
 [dependencies]
 quote = "^0.3.15"
 syn = "^0.11.11"
-rand = "0.5"
 
 [dev-dependencies.quickcheck]
 path = ".."

--- a/quickcheck_derive/Cargo.toml
+++ b/quickcheck_derive/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
-authors = ["Nathaniel Ringo <remexre@gmail.com>"]
+authors = [
+  "Nathaniel Ringo <remexre@gmail.com>",
+  "Felix Chapman <aelred717@gmail.com>",
+  "Michael Howell <michael@notriddle.com>"
+]
 description = "#[derive(Arbitrary, Clone)]"
 license = "MIT"
 name = "quickcheck_derive"

--- a/quickcheck_derive/Cargo.toml
+++ b/quickcheck_derive/Cargo.toml
@@ -12,7 +12,7 @@ rand = "0.5"
 
 [dev-dependencies.quickcheck]
 path = ".."
-version = "0.7.2"
+version = "0.8.0"
 
 [lib]
 proc-macro = true

--- a/quickcheck_derive/Cargo.toml
+++ b/quickcheck_derive/Cargo.toml
@@ -11,7 +11,7 @@ syn = "^0.11.11"
 
 [dev-dependencies.quickcheck]
 path = ".."
-version = "0.6"
+version = "0.7.2"
 
 [lib]
 proc-macro = true

--- a/quickcheck_derive/src/structural.rs
+++ b/quickcheck_derive/src/structural.rs
@@ -21,7 +21,10 @@ pub fn derive_struct(item: &DeriveInput, variant: &VariantData) -> (Tokens, Toke
                     (quote!((#(self.#field_names),*)), quote!(#alpha))
                 },
                 length if length > 8 => {
-                    (quote!(tuplify!(#(self.#field_names),*)), quote!(tuplify!(#(#alphas),*)))
+                    (
+                        quote!(tuplify!(#(self.#field_names),*)),
+                        quote!(tuplify_pattern!(#(#alphas),*))
+                    )
                 },
                 _ => (quote!((#(self.#field_names),*)), quote!((#(#alphas),*))),
             };

--- a/quickcheck_derive/src/structural.rs
+++ b/quickcheck_derive/src/structural.rs
@@ -22,11 +22,16 @@ pub fn derive_struct(item: &DeriveInput, variant: &VariantData) -> (Tokens, Toke
                 },
                 length if length > 8 => {
                     (
-                        quote!(tuplify!(#(self.#field_names),*)),
+                        quote!({let k = self.clone(); tuplify!(#(k.#field_names),*)}),
                         quote!(tuplify_pattern!(#(#alphas),*))
                     )
                 },
-                _ => (quote!((#(self.#field_names),*)), quote!((#(#alphas),*))),
+                _ => {
+                    (
+                        quote!({let k = self.clone(); (#(k.#field_names),*)}),
+                        quote!((#(#alphas),*))
+                    )
+                },
             };
 
             quote! {

--- a/quickcheck_derive/src/structural.rs
+++ b/quickcheck_derive/src/structural.rs
@@ -82,8 +82,7 @@ pub fn derive_enum(item: &DeriveInput, variants: &[Variant]) -> (Tokens, Tokens)
     let shrink_variants = variants.iter().map(|v| enum_shrink_variant(name, v));
 
     let arbitrary = quote! {
-        extern crate rand;
-        match rand::Rng::gen_range(_g, 0, #variant_count) {
+        match ::quickcheck::Rng::gen_range(_g, 0, #variant_count) {
             #(#arbitrary_variants,)*
             _ => unreachable!(),
         }

--- a/quickcheck_derive/src/structural.rs
+++ b/quickcheck_derive/src/structural.rs
@@ -82,7 +82,8 @@ pub fn derive_enum(item: &DeriveInput, variants: &[Variant]) -> (Tokens, Tokens)
     let shrink_variants = variants.iter().map(|v| enum_shrink_variant(name, v));
 
     let arbitrary = quote! {
-        match _g.gen_range(0, #variant_count) {
+        extern crate rand;
+        match rand::Rng::gen_range(_g, 0, #variant_count) {
             #(#arbitrary_variants,)*
             _ => unreachable!(),
         }

--- a/quickcheck_derive/tests/move_type.rs
+++ b/quickcheck_derive/tests/move_type.rs
@@ -1,0 +1,52 @@
+#[macro_use]
+extern crate quickcheck;
+#[macro_use]
+extern crate quickcheck_derive;
+
+// Based on code in rust-content-security-policy
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq)]
+#[arbitrary(constraint = "self.is_valid()")]
+pub struct Directive {
+    name: String,
+    value: Vec<String>,
+}
+
+impl Directive {
+    pub fn is_valid(&self) -> bool {
+        true
+    }
+}
+
+quickcheck! {
+    fn struct_constraint(t: Directive) -> bool {
+        t.is_valid()
+    }
+}
+
+// Since there's different code triggered for length > 8
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq)]
+#[arbitrary(constraint = "self.is_valid()")]
+pub struct GiantDirective {
+    v1: String,
+    v2: String,
+    v3: String,
+    v4: String,
+    v5: String,
+    v6: String,
+    v7: String,
+    v8: String,
+    v9: String,
+    v10: String,
+}
+
+impl GiantDirective {
+    pub fn is_valid(&self) -> bool {
+        true
+    }
+}
+
+quickcheck! {
+    fn struct_constraint_giant(t: GiantDirective) -> bool {
+        t.is_valid()
+    }
+}

--- a/quickcheck_macros/Cargo.toml
+++ b/quickcheck_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickcheck_macros"
-version = "0.7.0"  #:version
+version = "0.8.0"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "A macro attribute for quickcheck."
 documentation = "http://burntsushi.net/rustdoc/quickcheck/"
@@ -22,4 +22,4 @@ quote = "0.6.8"
 syn = { version = "0.15", features = ["full"] }
 
 [dev-dependencies]
-quickcheck = { path = "..", version = "0.7.2" }
+quickcheck = { path = "..", version = "0.8.0" }

--- a/quickcheck_macros/Cargo.toml
+++ b/quickcheck_macros/Cargo.toml
@@ -9,16 +9,13 @@ repository = "https://github.com/BurntSushi/quickcheck"
 readme = "../README.md"
 keywords = ["testing", "quickcheck", "property", "shrinking", "fuzz"]
 license = "Unlicense/MIT"
+autotests = false
 
 [lib]
 name = "quickcheck_macros"
 path = "src/lib.rs"
 plugin = true
 
-[[test]]
-name = "attribute"
-path = "examples/attribute.rs"
-
 [dependencies.quickcheck]
 path = ".."
-version = "0.6"
+version = "0.7.1"

--- a/quickcheck_macros/Cargo.toml
+++ b/quickcheck_macros/Cargo.toml
@@ -14,8 +14,12 @@ autotests = false
 [lib]
 name = "quickcheck_macros"
 path = "src/lib.rs"
-plugin = true
+proc-macro = true
 
-[dependencies.quickcheck]
-path = ".."
-version = "0.7.1"
+[dependencies]
+proc-macro2 = "0.4.19"
+quote = "0.6.8"
+syn = { version = "0.15", features = ["full"] }
+
+[dev-dependencies]
+quickcheck = { path = "..", version = "0.7.2" }

--- a/quickcheck_macros/Cargo.toml
+++ b/quickcheck_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickcheck_macros"
-version = "0.6.2"  #:version
+version = "0.7.0"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "A macro attribute for quickcheck."
 documentation = "http://burntsushi.net/rustdoc/quickcheck/"

--- a/quickcheck_macros/examples/attribute.rs
+++ b/quickcheck_macros/examples/attribute.rs
@@ -1,9 +1,9 @@
-#![feature(custom_attribute)]
-#![feature(plugin)]
 #![allow(dead_code)]
-#![plugin(quickcheck_macros)]
 
 extern crate quickcheck;
+extern crate quickcheck_macros;
+
+use quickcheck_macros::quickcheck;
 
 fn reverse<T: Clone>(xs: &[T]) -> Vec<T> {
     let mut rev = vec!();

--- a/quickcheck_macros/src/lib.rs
+++ b/quickcheck_macros/src/lib.rs
@@ -12,7 +12,7 @@ extern crate rustc_plugin;
 
 use syntax::ast;
 use syntax::ast::{Ident, ItemKind, PatKind, StmtKind, Stmt, TyKind};
-use syntax::codemap;
+use syntax::source_map;
 use syntax::ext::base::{ExtCtxt, MultiModifier, Annotatable};
 use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
@@ -48,7 +48,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
 /// }
 /// ```
 fn expand_meta_quickcheck(cx: &mut ExtCtxt,
-                          span: codemap::Span,
+                          span: source_map::Span,
                           _: &ast::MetaItem,
                           annot_item: Annotatable) -> Annotatable {
     let item = annot_item.expect_item();
@@ -85,7 +85,7 @@ fn expand_meta_quickcheck(cx: &mut ExtCtxt,
 }
 
 fn wrap_item(cx: &mut ExtCtxt,
-             span: codemap::Span,
+             span: source_map::Span,
              item: &ast::Item,
              inner_ident: P<ast::Expr>) -> Annotatable {
     // Copy original function without attributes

--- a/quickcheck_macros/tests/macro.rs
+++ b/quickcheck_macros/tests/macro.rs
@@ -1,11 +1,10 @@
-#![feature(plugin)]
-
 #![allow(non_upper_case_globals)]
-#![plugin(quickcheck_macros)]
 
 extern crate quickcheck;
+extern crate quickcheck_macros;
 
 use quickcheck::TestResult;
+use quickcheck_macros::quickcheck;
 
 #[quickcheck]
 fn min(x: isize, y: isize) -> TestResult {

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -748,7 +748,7 @@ macro_rules! unsigned_arbitrary {
 unsigned_arbitrary! {
     usize, u8, u16, u32, u64
 }
-#[cfg(feature = "i128")]
+
 unsigned_arbitrary! {
     u128
 }
@@ -821,7 +821,7 @@ macro_rules! signed_arbitrary {
 signed_arbitrary! {
     isize, i8, i16, i32, i64
 }
-#[cfg(feature = "i128")]
+
 signed_arbitrary! {
     i128
 }
@@ -1077,7 +1077,6 @@ mod test {
         eq(0i64, vec![]);
     }
 
-    #[cfg(feature="i128")]
     #[test]
     fn ints128() {
         eq(5i128, vec![0, 3, 4]);
@@ -1115,7 +1114,6 @@ mod test {
         eq(0u64, vec![]);
     }
 
-    #[cfg(feature = "i128")]
     #[test]
     fn uints128() {
         eq(5u128, vec![0, 3, 4]);

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -22,6 +22,9 @@ use std::time::{UNIX_EPOCH, Duration, SystemTime};
 use rand::{self, Rng, RngCore};
 use rand::seq::SliceRandom;
 
+#[cfg(feature = "derive")]
+pub use quickcheck_derive::Arbitrary;
+
 /// `Gen` wraps a `rand::RngCore` with parameters to control the distribution of
 /// random values.
 ///

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -543,6 +543,7 @@ impl Arbitrary for PathBuf {
         let here = env::current_dir()
             .unwrap_or(PathBuf::from("/test/directory"));
         let temp = env::temp_dir();
+        #[allow(deprecated)]
         let home = env::home_dir()
             .unwrap_or(PathBuf::from("/home/user"));
         let choices = &[

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -39,13 +39,14 @@ pub struct StdGen<R> {
     size: usize,
 }
 
-/// Returns a `StdGen` with the given configuration using any random number
-/// generator.
-///
-/// The `size` parameter controls the size of random values generated.
-/// For example, it specifies the maximum length of a randomly generated vector
-/// and also will specify the maximum magnitude of a randomly generated number.
 impl<R: RngCore> StdGen<R> {
+    /// Returns a `StdGen` with the given configuration using any random number
+    /// generator.
+    ///
+    /// The `size` parameter controls the size of random values generated. For
+    /// example, it specifies the maximum length of a randomly generated vector
+    /// and also will specify the maximum magnitude of a randomly generated
+    /// number.
     pub fn new(rng: R, size: usize) -> StdGen<R> {
         StdGen { rng: rng, size: size }
     }
@@ -65,6 +66,39 @@ impl<R: RngCore> RngCore for StdGen<R> {
 
 impl<R: RngCore> Gen for StdGen<R> {
     fn size(&self) -> usize { self.size }
+}
+
+/// StdThreadGen is an RNG in thread-local memory.
+///
+/// This is the default RNG used by quickcheck.
+pub struct StdThreadGen(StdGen<rand::rngs::ThreadRng>);
+
+impl StdThreadGen {
+    /// Returns a new thread-local RNG.
+    ///
+    /// The `size` parameter controls the size of random values generated. For
+    /// example, it specifies the maximum length of a randomly generated vector
+    /// and also will specify the maximum magnitude of a randomly generated
+    /// number.
+    pub fn new(size: usize) -> StdThreadGen {
+        StdThreadGen(StdGen { rng: rand::thread_rng(), size: size })
+    }
+}
+
+impl RngCore for StdThreadGen {
+    fn next_u32(&mut self) -> u32 { self.0.next_u32() }
+
+    // some RNGs implement these more efficiently than the default, so
+    // we might as well defer to them.
+    fn next_u64(&mut self) -> u64 { self.0.next_u64() }
+    fn fill_bytes(&mut self, dest: &mut [u8]) { self.0.fill_bytes(dest) }
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        self.0.try_fill_bytes(dest)
+    }
+}
+
+impl Gen for StdThreadGen {
+    fn size(&self) -> usize { self.0.size }
 }
 
 /// Creates a shrinker with zero elements.

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -19,14 +19,14 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use rand::Rng;
+use rand::{self, Rng, RngCore};
 
-/// `Gen` wraps a `rand::Rng` with parameters to control the distribution of
+/// `Gen` wraps a `rand::RngCore` with parameters to control the distribution of
 /// random values.
 ///
 /// A value with type satisfying the `Gen` trait can be constructed with the
 /// `gen` function in this crate.
-pub trait Gen : Rng {
+pub trait Gen : RngCore {
     fn size(&self) -> usize;
 }
 
@@ -45,22 +45,25 @@ pub struct StdGen<R> {
 /// The `size` parameter controls the size of random values generated.
 /// For example, it specifies the maximum length of a randomly generated vector
 /// and also will specify the maximum magnitude of a randomly generated number.
-impl<R: Rng> StdGen<R> {
+impl<R: RngCore> StdGen<R> {
     pub fn new(rng: R, size: usize) -> StdGen<R> {
         StdGen { rng: rng, size: size }
     }
 }
 
-impl<R: Rng> Rng for StdGen<R> {
+impl<R: RngCore> RngCore for StdGen<R> {
     fn next_u32(&mut self) -> u32 { self.rng.next_u32() }
 
     // some RNGs implement these more efficiently than the default, so
     // we might as well defer to them.
     fn next_u64(&mut self) -> u64 { self.rng.next_u64() }
     fn fill_bytes(&mut self, dest: &mut [u8]) { self.rng.fill_bytes(dest) }
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        self.rng.try_fill_bytes(dest)
+    }
 }
 
-impl<R: Rng> Gen for StdGen<R> {
+impl<R: RngCore> Gen for StdGen<R> {
     fn size(&self) -> usize { self.size }
 }
 

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rand::{self, Rng, RngCore};
+use rand::seq::SliceRandom;
 
 /// `Gen` wraps a `rand::RngCore` with parameters to control the distribution of
 /// random values.
@@ -555,7 +556,7 @@ impl Arbitrary for PathBuf {
             PathBuf::from("../../.."),
             PathBuf::new(),
         ];
-        let mut p = g.choose(choices).unwrap().clone();
+        let mut p = choices.choose(g).unwrap().clone();
         p.extend(Vec::<OsString>::arbitrary(g).iter());
         p
     }
@@ -633,7 +634,7 @@ impl Arbitrary for char {
             }
             60...84 => {
                 // Characters often used in programming languages
-                *g.choose(&[
+                [
                     ' ', ' ', ' ',
                     '\t',
                     '\n',
@@ -641,11 +642,11 @@ impl Arbitrary for char {
                     '_', '-', '=', '+','[', ']', '{', '}', ':', ';', '\'', '"',
                     '\\', '|',',','<','>','.','/','?',
                     '0', '1','2','3','4','5','6','7','8','9',
-                ]).unwrap()
+                ].choose(g).unwrap().to_owned()
             }
             85...89 => {
                 // Tricky Unicode, part 1
-                *g.choose(&[
+                [
                     '\u{0149}', // a deprecated character
                     '\u{fff0}', // some of "Other, format" category:
                     '\u{fff1}','\u{fff2}','\u{fff3}','\u{fff4}','\u{fff5}',
@@ -667,7 +668,7 @@ impl Arbitrary for char {
                     '\u{1680}',
                     // other space characters are already covered by two next
                     // branches
-                ]).unwrap()
+                ].choose(g).unwrap().to_owned()
             }
             90...94 => {
                 // Tricky unicode, part 2
@@ -980,7 +981,7 @@ mod test {
         super::Arbitrary::arbitrary(&mut gen())
     }
 
-    fn gen() -> super::StdGen<rand::ThreadRng> {
+    fn gen() -> super::StdGen<rand::rngs::ThreadRng> {
         super::StdGen::new(rand::thread_rng(), 5)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,9 +97,30 @@ macro_rules! tuplify {
     };
 }
 
+#[macro_export]
+macro_rules! tuplify_pattern {
+    () => {
+        ()
+    };
+
+    ($p:pat) => {
+        $p
+    };
+
+    ($tuple_pattern:pat, $($tail:pat),+) => {
+        ($tuple_pattern, tuplify_pattern!($($tail),+))
+    };
+}
+
 #[test]
 fn tuplifiy_test() {
     assert_eq!((1, (2, (3, 4))), tuplify!(1,2,3,4));
+}
+
+#[test]
+fn tuplify_pattern_test() {
+    let tuplify_pattern!(a, b, c) = tuplify!(1, 2, 3);
+    assert_eq!((a, b, c), (1, 2, 3));
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,34 +84,22 @@ macro_rules! info {
 
 #[macro_export]
 macro_rules! tuplify {
-    (@as_expr $e:expr) => { $e };
-    
-    (@parse { } -> { $($output:tt)* }) => {
-        tuplify!(@as_expr $($output)* )
+    () => {
+        ()
     };
 
-    (@parse { $($tuple_item:expr)*, $($tail:tt)* } -> { }) => {
-        tuplify!(@parse { $($tail)* } -> { $($tuple_item)* })
-    };
-    
-    (@parse { $($tuple_item:expr)*, $($tail:tt)* } -> { $($output:tt)* }) => {
-        tuplify!(@parse { $($tail)* } -> { ($($output)*, $($tuple_item)*) })
+    ($e:expr) => {
+        $e
     };
 
-    (@parse { $($tuple_item:expr)* } -> { $($output:tt)* }) => {
-        tuplify!(@parse { } -> { ($($output)*, $($tuple_item)*) })
+    ($tuple_item:expr, $($tail:expr),+) => {
+        ($tuple_item, tuplify!($($tail),+))
     };
-
-    (@parse { $t:tt $($ts:tt)* } -> { $($output:tt)* }) => {
-        tuplify!(@parse { $($ts)* } -> { $($output)* })
-    };
-
-    ($($tail:tt)*) => (tuplify!(@parse { $($tail)* } -> { }));
 }
 
 #[test]
 fn tuplifiy_test() {
-    assert_eq!(((((1,2),3),4)), tuplify!(1,2,3,4));
+    assert_eq!((1, (2, (3, 4))), tuplify!(1,2,3,4));
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,16 @@
 #[cfg(feature = "use_logging")]
 extern crate env_logger;
 #[cfg(feature = "use_logging")]
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 extern crate rand;
+extern crate rand_core;
 
 pub use arbitrary::{
-    Arbitrary, Gen, StdGen,
+    Arbitrary, Gen, StdGen, StdThreadGen,
     empty_shrinker, single_shrinker,
 };
-pub use rand::Rng;
+pub use rand_core::RngCore;
 pub use tester::{QuickCheck, Testable, TestResult, quickcheck};
 
 /// A macro for writing quickcheck tests.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ extern crate env_logger;
 extern crate log;
 extern crate rand;
 extern crate rand_core;
+#[cfg(feature = "derive")]
+extern crate quickcheck_derive;
 
 pub use arbitrary::{
     Arbitrary, Gen, StdGen, StdThreadGen,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,8 @@ pub use arbitrary::{
     Arbitrary, Gen, StdGen, StdThreadGen,
     empty_shrinker, single_shrinker,
 };
-pub use rand_core::RngCore;
+pub use rand::RngCore;
+pub use rand::Rng;
 pub use tester::{QuickCheck, Testable, TestResult, quickcheck};
 
 /// A macro for writing quickcheck tests.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@
 //! For detailed examples, please see the
 //! [README](https://github.com/BurntSushi/quickcheck).
 
-#![allow(deprecated)] // for connect -> join in 1.3
-
 #![cfg_attr(feature = "i128", feature(i128_type, i128))]
 
 #[cfg(feature = "use_logging")]

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -410,7 +410,7 @@ impl<A: Arbitrary + Debug> AShow for A {}
 #[cfg(test)]
 mod test {
     use {QuickCheck, StdGen};
-    use rand::{self, OsRng};
+    use rand::{self, rngs::OsRng};
 
     #[test]
     fn shrinking_regression_issue_126() {

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -3,10 +3,8 @@ use std::panic;
 use std::env;
 use std::cmp;
 
-use rand;
-
 use tester::Status::{Discard, Fail, Pass};
-use {Arbitrary, Gen, StdGen};
+use {Arbitrary, Gen, StdThreadGen};
 
 /// The main QuickCheck type for setting configuration and running QuickCheck.
 pub struct QuickCheck<G> {
@@ -48,7 +46,7 @@ fn qc_min_tests_passed() -> u64 {
     }
 }
 
-impl QuickCheck<StdGen<rand::ThreadRng>> {
+impl QuickCheck<StdThreadGen> {
     /// Creates a new QuickCheck value.
     ///
     /// This can be used to run QuickCheck on things that implement
@@ -57,11 +55,10 @@ impl QuickCheck<StdGen<rand::ThreadRng>> {
     ///
     /// By default, the maximum number of passed tests is set to `100`,
     /// the max number of overall tests is set to `10000` and the generator
-    /// is set to a `StdGen` with a default size of `100`.
-    pub fn new() -> QuickCheck<StdGen<rand::ThreadRng>> {
+    /// is set to a `StdThreadGen` with a default size of `100`.
+    pub fn new() -> QuickCheck<StdThreadGen> {
         let gen_size = qc_gen_size();
-
-        QuickCheck::with_gen(StdGen::new(rand::thread_rng(), gen_size))
+        QuickCheck::with_gen(StdThreadGen::new(gen_size))
     }
 }
 

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -270,12 +270,12 @@ impl TestResult {
         match self.err {
             None => {
                 format!("[quickcheck] TEST FAILED. Arguments: ({})",
-                        self.arguments.connect(", "))
+                        self.arguments.join(", "))
             }
             Some(ref err) => {
                 format!("[quickcheck] TEST FAILED (runtime error). \
                          Arguments: ({})\nError: {}",
-                        self.arguments.connect(", "), err)
+                        self.arguments.join(", "), err)
             }
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,9 +1,12 @@
 use std::cmp::Ord;
-use rand;
-use super::{QuickCheck, StdGen, TestResult, quickcheck};
 use std::collections::{HashSet, HashMap};
-use std::hash::{BuildHasherDefault, SipHasher};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::BuildHasherDefault;
 use std::path::PathBuf;
+
+use rand;
+
+use super::{QuickCheck, StdGen, TestResult, quickcheck};
 
 #[test]
 fn prop_oob() {
@@ -256,13 +259,13 @@ quickcheck! {
     }
 
     fn substitute_hashset(
-        _set: HashSet<u8, BuildHasherDefault<SipHasher>>
+        _set: HashSet<u8, BuildHasherDefault<DefaultHasher>>
     ) -> bool {
         true
     }
 
     fn substitute_hashmap(
-        _map: HashMap<u8, u8, BuildHasherDefault<SipHasher>>
+        _map: HashMap<u8, u8, BuildHasherDefault<DefaultHasher>>
     ) -> bool {
         true
     }


### PR DESCRIPTION
I wanted to fix the last issue in BurntSushi/quickcheck#205 so I could learn how to debug and write Rust macros.

The problem was that the `tuplify!` macro operates on expressions and returns an expression. But in
just one case a pattern is expected, not an arbitrary expression:

```
foo.map(|tuplify!(a, b)| bar(a, b));
//       ~~~~~~~~~~~~~~ this should be a pattern, not an expression
// the above expands to:
foo.map(|(a, b)| bar(a, b));
```

Even though the final code is valid Rust, the tokens are of the wrong type.

The problem is fixed using a new macro `tuplify_pattern!` that operates exclusively on patterns.

I also rewrote `tuplify!` to match `tuplify_pattern!`. I think it's neater - although the result is flipped from `((a, b), c)` to `(a, (b, c))`. If there's a reason for it to behave the previous way, I can revert it.